### PR TITLE
Reduce Producer.Retry.Max

### DIFF
--- a/transports/kafka.go
+++ b/transports/kafka.go
@@ -81,7 +81,7 @@ func ParseKafkaURL(brokerURL string) ([]string, *sarama.Config) {
   if val, err := strconv.Atoi(parsedURL.Query().Get("message.send.max.retries")); err == nil {
     config.Producer.Retry.Max = val
   } else {
-    config.Producer.Retry.Max = 10000000
+    config.Producer.Retry.Max = 100
   }
   if val, err := strconv.Atoi(parsedURL.Query().Get("request.required.acks")); err == nil {
     config.Producer.RequiredAcks = sarama.RequiredAcks(val)


### PR DESCRIPTION
Sarama needs to allocate

    max.message.bytes * Producer.Retry.Max * numPartitions

bytes of RAM for buffering messages. Having a very high
Producer.Retry.Max protects against producer disruptions, but
a value as high as this across a high number of topics and
partitions becomes unmanageable in terms of RAM.