### PR TITLE
Don't block on websocket reconnects

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/openrelayxyz/cardinal-rpc v1.0.0 h1:HaR/Uz6l2hqTCChQROS2d3pE2KEnPoaSC
 github.com/openrelayxyz/cardinal-rpc v1.0.0/go.mod h1:5eOYxJLylOVHjJZJvsspSlAbfGSjETLV71x0QwpeMZ4=
 github.com/openrelayxyz/cardinal-types v1.0.0 h1:/H+TvMIoOwp5ub+jgwlrsC41bWSHFye+oz5SLktgGhs=
 github.com/openrelayxyz/cardinal-types v1.0.0/go.mod h1:4CzsdfRjAWXeOszcXbUuNNjEP7ZR8Np8RO3FO5TFA6E=
-github.com/openrelayxyz/drumline v1.0.0-stepsize0 h1:EIpFQDE7mZmmUFfInMO1GhZzPuTSO7hnyIr0t8e85n8=
-github.com/openrelayxyz/drumline v1.0.0-stepsize0/go.mod h1:wHb9N0b4UBYtxa8+atz9b3F5kIb70p7NMmWxNeSxhJ0=
+github.com/openrelayxyz/drumline v1.0.0 h1:v46mMg2eRQ7RFfwVLUdtawUDbzupNAHdVyWtubxLGps=
+github.com/openrelayxyz/drumline v1.0.0/go.mod h1:wHb9N0b4UBYtxa8+atz9b3F5kIb70p7NMmWxNeSxhJ0=
 github.com/pierrec/lz4 v2.6.0+incompatible h1:Ix9yFKn1nSPBLFl/yZknTp8TU5G4Ps0JDmguYK6iH1A=
 github.com/pierrec/lz4 v2.6.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/transports/websockets.go
+++ b/transports/websockets.go
@@ -299,7 +299,7 @@ func newWebsocketConsumer(omp *delivery.OrderedMessageProcessor, url string, las
 
 func (c *websocketConsumer) Start() error {
 	var err error
-	connected := make(chan struct{})
+	connected := make(chan struct{}, 8)
 	isReady := false
 	go func() {
 		for !c.quit {
@@ -352,7 +352,10 @@ func (c *websocketConsumer) Start() error {
 			}
 			log.Info("Subscription established", "id", subid)
 			var notification rpc.SubscriptionResponseRaw
-			connected <- struct{}{}
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
 			for {
 				_, message, err := c.conn.ReadMessage()
 				if err != nil {


### PR DESCRIPTION
The connection channel in websocket streams is intended to block the Start() process until the connection is established, but sending on the connection channel ends up causing reconnects to block.

This uses a select / case to skip over the send if the connected channel blocks so that reconnects still happen.