### PR TITLE
Feature/producer count

### DIFF
--- a/delivery/types.go
+++ b/delivery/types.go
@@ -90,6 +90,7 @@ const (
   BatchDeleteMsgType            // BatchDeleteMsgType.$hash./path/
   ReorgType                     // ReorgType.$Hash
   ReorgCompleteType             // ReorgCompleteType.$Hash
+  PingType MessageType = 0xff
 )
 
 func (mt MessageType) GetKey(components ...[]byte) []byte {

--- a/transports/interfaces.go
+++ b/transports/interfaces.go
@@ -25,6 +25,8 @@ type Producer interface {
   // after all blocks and batches for a given reorg have been sent to the
   // producer.
   Reorg(number int64, hash types.Hash) (func(), error)
+  // SetHealth allows producers to mark that they are in an unhealthy state and not currently producing
+  SetHealth(bool)
 }
 
 // Consumer can be used to receive messages over a transport layer.

--- a/transports/interfaces.go
+++ b/transports/interfaces.go
@@ -3,11 +3,17 @@ package transports
 import (
   "math/big"
   "github.com/openrelayxyz/cardinal-types"
+  "time"
   // "github.com/openrelayxyz/cardinal-streams/delivery"
 )
 
+type ProducerCounter interface {
+  ProducerCount(time.Duration) uint
+}
+
 // Producer can be used to send block metadata over a messaging transport.
 type Producer interface {
+  ProducerCounter
   LatestBlockFromFeed() (int64, error)
   // AddBlock will send information about a block over the transport layer.
   AddBlock(number int64, hash, parentHash types.Hash, weight *big.Int, updates map[string][]byte, deletes map[string]struct{}, batches map[string]types.Hash) error
@@ -23,6 +29,7 @@ type Producer interface {
 
 // Consumer can be used to receive messages over a transport layer.
 type Consumer interface {
+  ProducerCounter
   // Start sets up communication with the broker and begins processing
   // messages. If you want to ensure receipt of 100% of messages, you should
   // call Start() only after setting up subscriptions with Subscribe()

--- a/transports/kafka.go
+++ b/transports/kafka.go
@@ -1,15 +1,18 @@
 package transports
 
 import (
+  "bytes"
   "fmt"
   "math/big"
   "github.com/Shopify/sarama"
+	"github.com/hashicorp/golang-lru"
   "github.com/openrelayxyz/cardinal-types"
   "github.com/openrelayxyz/cardinal-types/metrics"
   "github.com/openrelayxyz/cardinal-streams/delivery"
   "github.com/openrelayxyz/drumline"
   log "github.com/inconshreveable/log15"
   coreLog "log"
+  "math/rand"
   "net/url"
   "regexp"
   "strings"
@@ -18,6 +21,22 @@ import (
   "time"
   "os"
 )
+
+type pingTracker map[types.Hash]time.Time
+
+func (pt pingTracker) update(key types.Hash) {
+  pt[key] = time.Now()
+}
+
+func (pt pingTracker) ProducerCount(d time.Duration) uint {
+  var count uint
+  for _, v := range pt {
+    if time.Since(v) < d {
+      count++
+    }
+  }
+  return count
+}
 
 type KafkaResumptionMessage struct {
   msg *sarama.ConsumerMessage
@@ -193,9 +212,17 @@ type KafkaProducer struct{
   reorgTopic   string
   defaultTopic string
   brokerURL    string
+  latestNumber int64
+  recentHashes *lru.Cache
+  skipBatches  *lru.Cache
+  pt           pingTracker
+  healthy      bool
 }
 
 func NewKafkaProducer(brokerURL, defaultTopic string, schema map[string]string) (Producer, error) {
+  r := rand.New(rand.NewSource(time.Now().UnixNano())) // Not cryptographically secure, but fine for unique producer IDs
+  var idBytes[32]byte
+  r.Read(idBytes[:])
   dp, err := delivery.NewProducer(defaultTopic, schema)
   if err != nil { return nil, err }
   brokers, config := ParseKafkaURL(strings.TrimPrefix(brokerURL, "kafka://"))
@@ -217,10 +244,89 @@ func NewKafkaProducer(brokerURL, defaultTopic string, schema map[string]string) 
     ticker := time.NewTicker(30 * time.Second)
     for t := range ticker.C {
       b, _ := t.MarshalBinary()
-      producer.Input() <- &sarama.ProducerMessage{Topic: defaultTopic, Value: sarama.ByteEncoder(b)}
+      producer.Input() <- &sarama.ProducerMessage{Topic: defaultTopic, Key: sarama.ByteEncoder(delivery.PingType.GetKey(idBytes[:])), Value: sarama.ByteEncoder(b)}
     }
   }()
-  return &KafkaProducer{dp: dp, producer: producer, reorgTopic: "", defaultTopic: defaultTopic, brokerURL: brokerURL}, nil
+  pt := make(pingTracker)
+  client, err := sarama.NewClient(brokers, config)
+  if err != nil { return nil, err }
+  consumer, err := sarama.NewConsumerFromClient(client)
+  if err != nil { return nil, err }
+  partitions, err := consumer.Partitions(defaultTopic)
+  if err != nil { return nil, err }
+  batches := make(chan *delivery.Batch)
+  heartbeats := make(chan types.Hash)
+  var readyWg sync.WaitGroup
+  for _, partid := range partitions {
+    readyWg.Add(1)
+    go func(partid int32, readyWg *sync.WaitGroup) {
+      var once sync.Once
+      offset, err := client.GetOffset(defaultTopic, partid, sarama.OffsetNewest)
+      if err != nil {
+        offset = sarama.OffsetNewest
+        once.Do(readyWg.Done)
+      } else if offset == 0 {
+        offset = sarama.OffsetNewest
+        once.Do(readyWg.Done)
+      }
+      offset -= 100
+      if offset < 0 { offset = sarama.OffsetOldest }
+      pc, err := consumer.ConsumePartition(defaultTopic, partid, offset)
+      if err != nil {
+        pc, err = consumer.ConsumePartition(defaultTopic, partid, sarama.OffsetOldest)
+        if err != nil {
+          once.Do(readyWg.Done)
+          return
+        }
+      }
+      PARTITION_LOOP:
+      for {
+        select {
+        case input := <-pc.Messages():
+          if input == nil { break PARTITION_LOOP }
+          if hwm := pc.HighWaterMarkOffset(); hwm - input.Offset <= 1 {
+            once.Do(readyWg.Done)
+          }
+          if len(input.Key) == 0 { continue PARTITION_LOOP }
+          switch delivery.MessageType(input.Key[0]) {
+          case delivery.BatchType:
+            b, err := delivery.UnmarshalBatch(input.Value)
+            if err != nil {
+              log.Warn("Error unmarshalling batch", "err", err)
+              continue
+            }
+            batches <- b
+          case delivery.PingType:
+            if !bytes.Equal(input.Key[1:], idBytes[:]) { // Ignore our own heartbeats
+              heartbeats <- types.BytesToHash(input.Key[1:])
+            }
+          }
+        }
+      }
+    }(partid, &readyWg)
+  }
+  cache, _ := lru.New(4096)
+  skipBatches, _ := lru.New(1024)
+  kp := &KafkaProducer{dp: dp, producer: producer, reorgTopic: "", defaultTopic: defaultTopic, brokerURL: brokerURL, recentHashes: cache, skipBatches: skipBatches, pt: pt}
+  go func() {
+    for {
+      select {
+      case b := <-batches:
+        cache.Add(b.Hash, struct{}{})
+        if kp.latestNumber < b.Number {
+          kp.latestNumber = b.Number
+        }
+      case h := <-heartbeats:
+        kp.pt.update(h)
+      }
+    }
+  }()
+  readyWg.Wait()
+  return kp, nil
+}
+
+func (kp *KafkaProducer) ProducerCount(d time.Duration) uint {
+  return kp.pt.ProducerCount(d)
 }
 
 func (kp *KafkaProducer) emitBundle(bundle map[string][]delivery.Message) error {
@@ -244,11 +350,23 @@ func (kp *KafkaProducer) emit(topic string, msg delivery.Message) error {
 }
 
 func (kp *KafkaProducer) AddBlock(number int64, hash, parentHash types.Hash, weight *big.Int, updates map[string][]byte, deletes map[string]struct{}, batches map[string]types.Hash) error {
+  if kp.recentHashes.Contains(hash) {
+    // We saw this block come from another producer, we don't need to rebroadcast
+    for _, v := range batches {
+      kp.skipBatches.Add(v, struct{}{})
+    }
+    return nil
+  }
   msgs, err := kp.dp.AddBlock(number, hash, parentHash, weight, updates, deletes, batches)
   if err != nil { return err }
   return kp.emitBundle(msgs)
 }
 func (kp *KafkaProducer) SendBatch(batchid types.Hash, delete []string, update map[string][]byte) error {
+  if kp.skipBatches.Contains(batchid) {
+    // This batch is in a block that we skipped broadcasting, so we don't send
+    // the batch either.
+    return nil
+  }
   msgs, err := kp.dp.SendBatch(batchid, delete, update)
   if err != nil { return err }
   return kp.emitBundle(msgs)
@@ -344,6 +462,7 @@ type KafkaConsumer struct{
   shutdownWg   sync.WaitGroup
   isReorg      bool
   startHash    types.Hash
+  pt           pingTracker
 }
 
 func kafkaConsumerWithOMP(omp *delivery.OrderedMessageProcessor, brokerURL, defaultTopic string, topics []string, resumption []byte, rollback int64, lastHash types.Hash) (Consumer, error) {
@@ -372,6 +491,7 @@ func kafkaConsumerWithOMP(omp *delivery.OrderedMessageProcessor, brokerURL, defa
     client: client,
     rollback: rollback,
     startHash: lastHash,
+    pt: make(pingTracker),
   }, nil
 }
 
@@ -415,6 +535,7 @@ func (kc *KafkaConsumer) Start() error {
   var readyWg, warmupWg, reorgWg sync.WaitGroup
   messages := make(chan *sarama.ConsumerMessage, 512) // 512 is arbitrary. Worked for Flume, but may require tuning for Cardinal
   partitionConsumers := []sarama.PartitionConsumer{}
+  heartbeats := make(chan types.Hash)
   for _, topic := range kc.topics {
     partitions, err := consumer.Partitions(topic)
     if err != nil { return err }
@@ -555,6 +676,8 @@ func (kc *KafkaConsumer) Start() error {
               log.Error("Error processing input:", "err", err, "key", input.Key, "msg", input.Value, "part", input.Partition, "offset", input.Offset)
             }
           }
+        case delivery.PingType:
+          heartbeats <- types.BytesToHash(msg.Key()[1:])
         case delivery.ReorgCompleteType:
           reorgWg.Done()
         default:
@@ -596,8 +719,20 @@ func (kc *KafkaConsumer) Start() error {
       }
     }
   }()
+  go func() {
+    for {
+      select {
+      case h := <-heartbeats:
+        kc.pt.update(h)
+      }
+    }
+  }()
   return nil
 }
+func (kc *KafkaConsumer) ProducerCount(d time.Duration) uint {
+  return kc.pt.ProducerCount(d)
+}
+
 func (kc *KafkaConsumer) Ready() <-chan struct{} {
   if kc.ready != nil { return kc.ready }
   r := make(chan struct{}, 1)

--- a/transports/null.go
+++ b/transports/null.go
@@ -1,6 +1,9 @@
 package transports
 
-import "github.com/openrelayxyz/cardinal-types"
+import (
+  "time"
+  "github.com/openrelayxyz/cardinal-types"
+  )
 
 type nullConsumer struct{}
 
@@ -24,6 +27,9 @@ func (*nullConsumer) Ready() <-chan struct{} {
 }
 func (*nullConsumer) WhyNotReady(hash types.Hash) string {
   return "null"
+}
+func (*nullConsumer) ProducerCount(time.Duration) uint {
+  return 0
 }
 
 

--- a/transports/resolver.go
+++ b/transports/resolver.go
@@ -5,6 +5,7 @@ import (
   "fmt"
   "math/big"
   "regexp"
+  "time"
   "strings"
   "github.com/openrelayxyz/cardinal-types"
   "github.com/openrelayxyz/cardinal-streams/delivery"
@@ -122,6 +123,14 @@ type muxConsumer struct {
   consumers []Consumer
 }
 
+func (mc *muxConsumer) ProducerCount(d time.Duration) uint {
+  var count uint
+  for _, c := range mc.consumers {
+    count += c.ProducerCount(d)
+  }
+  return count
+}
+
 func (mc *muxConsumer) Start() error {
   for _, c := range mc.consumers {
     if err := c.Start(); err != nil { return err }
@@ -167,6 +176,14 @@ func (mc *muxConsumer) WhyNotReady(h types.Hash) string {
 
 type muxProducer struct {
   producers []Producer
+}
+
+func (mc *muxProducer) ProducerCount(d time.Duration) uint {
+  var count uint
+  for _, c := range mc.producers {
+    count += c.ProducerCount(d)
+  }
+  return count
 }
 
 func (mp *muxProducer) LatestBlockFromFeed() (int64, error) {

--- a/transports/resolver.go
+++ b/transports/resolver.go
@@ -186,6 +186,12 @@ func (mc *muxProducer) ProducerCount(d time.Duration) uint {
   return count
 }
 
+func (mc *muxProducer) SetHealth(b bool) {
+  for _, p := range mc.producers {
+    p.SetHealth(b)
+  }
+}
+
 func (mp *muxProducer) LatestBlockFromFeed() (int64, error) {
 	n := int64(9223372036854775807)
 	var topErr error

--- a/transports/websockets.go
+++ b/transports/websockets.go
@@ -38,6 +38,7 @@ type websocketProducer struct {
 func (*websocketProducer) ProducerCount(time.Duration) uint {
   return 0
 }
+func (*websocketProducer) SetHealth(bool) {}
 
 type resultMessage struct {
 	Type string `json:"type"`

--- a/transports/websockets.go
+++ b/transports/websockets.go
@@ -35,6 +35,10 @@ type websocketProducer struct {
 	closemu sync.RWMutex
 }
 
+func (*websocketProducer) ProducerCount(time.Duration) uint {
+  return 0
+}
+
 type resultMessage struct {
 	Type string `json:"type"`
 	Batch *TransportBatch `json:"batch,omitempty"`
@@ -295,6 +299,10 @@ type websocketConsumer struct {
 
 func newWebsocketConsumer(omp *delivery.OrderedMessageProcessor, url string, lastNum int64, lastHash types.Hash) (Consumer, error) {
 	return &websocketConsumer{url: strings.TrimPrefix(url, "cardinal://"), omp: omp, ready: make(chan struct{}), lastNum: hexutil.Uint64(lastNum), lastHash: lastHash}, nil
+}
+
+func (*websocketConsumer) ProducerCount(time.Duration) uint {
+  return 0
 }
 
 func (c *websocketConsumer) Start() error {


### PR DESCRIPTION
This commit does several things related to pings:

First, pings now include a randomized producer ID, so that consumers and producers can track the number of active producers they are in contact with.

Second, applications can set their producers as unhealthy to stop sending pings.

Third, producers will track the block hashes they've seen on the topic, and not rebroadcast blocks if they've seen the block come in before they broadcast it themselves (reducing duplicates on Kafka).