### PR TITLE
Remove reorg logic from kafka transport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/openrelayxyz/cardinal-rpc v1.1.0
 	github.com/openrelayxyz/cardinal-types v1.0.0
-	github.com/openrelayxyz/drumline v1.0.0
+	github.com/openrelayxyz/drumline v1.0.0-divide-by-zero0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/stretchr/testify v1.7.2 // indirect
 	github.com/xdg/scram v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/openrelayxyz/cardinal-rpc v1.1.0 h1:pOXIAF32LG80tVytdg7Y6z9rYJsBD5UnP
 github.com/openrelayxyz/cardinal-rpc v1.1.0/go.mod h1:UZ5KxcsG51ZMBHvLpaDoIReyHpGfGTkazuSKh8Lx4q8=
 github.com/openrelayxyz/cardinal-types v1.0.0 h1:/H+TvMIoOwp5ub+jgwlrsC41bWSHFye+oz5SLktgGhs=
 github.com/openrelayxyz/cardinal-types v1.0.0/go.mod h1:4CzsdfRjAWXeOszcXbUuNNjEP7ZR8Np8RO3FO5TFA6E=
-github.com/openrelayxyz/drumline v1.0.0 h1:v46mMg2eRQ7RFfwVLUdtawUDbzupNAHdVyWtubxLGps=
-github.com/openrelayxyz/drumline v1.0.0/go.mod h1:wHb9N0b4UBYtxa8+atz9b3F5kIb70p7NMmWxNeSxhJ0=
+github.com/openrelayxyz/drumline v1.0.0-divide-by-zero0 h1:iE+yIybj2sdS0aAzyGzxMj4N0vcP9sNpfMQckD/kRlE=
+github.com/openrelayxyz/drumline v1.0.0-divide-by-zero0/go.mod h1:wHb9N0b4UBYtxa8+atz9b3F5kIb70p7NMmWxNeSxhJ0=
 github.com/pierrec/lz4 v2.6.0+incompatible h1:Ix9yFKn1nSPBLFl/yZknTp8TU5G4Ps0JDmguYK6iH1A=
 github.com/pierrec/lz4 v2.6.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/transports/kafka.go
+++ b/transports/kafka.go
@@ -372,23 +372,25 @@ func (kp *KafkaProducer) SendBatch(batchid types.Hash, delete []string, update m
   return kp.emitBundle(msgs)
 }
 func (kp *KafkaProducer) Reorg(number int64, hash types.Hash) (func(), error) {
-  msg := kp.dp.Reorg(number, hash)
-  oldReorgTopic := kp.reorgTopic
-  kp.reorgTopic = fmt.Sprintf("%s-re-%x",  kp.defaultTopic, hash.Bytes())
-  done := func() {
-    kp.emit(kp.reorgTopic, kp.dp.ReorgDone(number, hash))
-    kp.reorgTopic = oldReorgTopic
-  }
-  if err := CreateTopicIfDoesNotExist(kp.brokerURL, kp.reorgTopic, 1, nil); err != nil {
-    done()
-    return func() {}, err
-  }
-  if err := kp.emit(kp.defaultTopic, msg); err != nil {
-    done()
-    return func(){}, err
-  }
-  kp.emit(kp.reorgTopic, msg)
-  return done, nil
+  // msg := kp.dp.Reorg(number, hash)
+  // oldReorgTopic := kp.reorgTopic
+  // kp.reorgTopic = fmt.Sprintf("%s-re-%x",  kp.defaultTopic, hash.Bytes())
+  // done := func() {
+  //   kp.emit(kp.reorgTopic, kp.dp.ReorgDone(number, hash))
+  //   kp.reorgTopic = oldReorgTopic
+  // }
+  // if err := CreateTopicIfDoesNotExist(kp.brokerURL, kp.reorgTopic, 1, nil); err != nil {
+  //   done()
+  //   return func() {}, err
+  // }
+  // if err := kp.emit(kp.defaultTopic, msg); err != nil {
+  //   done()
+  //   return func(){}, err
+  // }
+  // kp.emit(kp.reorgTopic, msg)
+  // return done, nil
+  log.Warn("Large reorg functionality disabled")
+  return func(){}, nil
 }
 
 

--- a/transports/resolver.go
+++ b/transports/resolver.go
@@ -171,16 +171,17 @@ func (mc *muxConsumer) Ready() <-chan struct{} {
   // }()
   // return ch
 
-  channels := make([]reflect.SelectCase, len(mc.consumers))
-  for i, c := range mc.consumers {
-    channels[i] = reflect.SelectCase{
-      Dir: reflect.SelectRecv,
-      Chan: reflect.ValueOf(c.Ready()),
+  go func() {
+    channels := make([]reflect.SelectCase, len(mc.consumers))
+    for i, c := range mc.consumers {
+      channels[i] = reflect.SelectCase{
+        Dir: reflect.SelectRecv,
+        Chan: reflect.ValueOf(c.Ready()),
+      }
     }
-  }
-  reflect.Select(channels)
-  
-  ch <- struct{}{}
+    reflect.Select(channels)
+    ch <- struct{}{}
+  }()
   return ch
 }
 


### PR DESCRIPTION
The reorg logic was well-intentioned but overly complicated. It never worked properly and caused things to get hung up and sometimes crash.

This doesn't totally pull out the re-org logic: most of the producer and consumer logic is still present, but the conditions that would trigger that logic will never be able to occur. At some point we may revisit making the logic work again, or may pull it out entirely.