### PR TITLE
Don't double count empty entries

### DIFF
--- a/delivery/consumer.go
+++ b/delivery/consumer.go
@@ -126,7 +126,14 @@ func (pb *PendingBatch) ApplyMessage(m ResumptionMessage) bool {
     return true
   case BatchMsgType:
     path := string(m.Key()[33:])
-    if v, ok := pb.Values[path]; ok && len(v) > 0 { return false } // Already set
+    if v, ok := pb.Values[path]; ok {
+      if len(v) == 0 && len(m.Value()) != 0 {
+        // If for some reason the stored value is empty but the message value is not, update to the message value
+        pb.Values[path] = m.Value()
+        return true
+      }
+      return false
+    } // Already set
     if pb.DecPrefixCounter(path) {
       // If this is false, we're not tracking this prefix and should ignore the message
       pb.Values[path] = m.Value()


### PR DESCRIPTION
I don't know why I originally had Cardinal Streams check that the previously stored value was non-empty before decrementing the prefix counter. When we started getting empty values coming across, this meant that those values got double counted, causing all sorts of problems.

I think it would have been perfectly okay to just check for the presence of the value and not consider its length at all. But out of an abundance of caution, and since I had already been doing a length check there that might have existed for an important reason, I've made the length check more sophisticated.

If the length of the stored value is 0 and the length of the message value is non-zero, then we'll replace the stored value with the message value but *not* decrement the prefix counter since this prefix has already been accounted for.